### PR TITLE
jh-ReadableDates #69

### DIFF
--- a/client/www/components/artist/artist.html
+++ b/client/www/components/artist/artist.html
@@ -16,9 +16,10 @@
         Upcoming Events:
       <div class="item item-body" ng-repeat="event in artist.artist_info.upcoming_events" ng-click="eventDetail(event)">
         <br> {{ event.title }}
-        <br> {{ event.datetime }}
+        <br> <mydate>{{ event.datetime | date: 'fullDate' }}</mydate>
       </div>
     </div>
     </div>
   </ion-content>
 </ion-view>
+

--- a/client/www/components/eventView/eventView.html
+++ b/client/www/components/eventView/eventView.html
@@ -8,7 +8,10 @@
                 <span class="input-label">Title</span><textarea placeholder="">{{event.title}}</textarea>
             </label>
             <label class="item item-input" name="date">
-                <span class="input-label">Date</span><textarea placeholder="">{{event.datetime}}</textarea>
+                <span class="input-label">Date</span>
+                  <textarea placeholder="">
+                    {{ event.datetime | date: 'fullDate' }}
+                  </textarea>
             </label>
             <label class="item item-input" name="description">
                 <span class="input-label">Description</span><textarea placeholder="">{{event.description}}</textarea>


### PR DESCRIPTION
1. Closes #69 
2. For future reference use :
{{ event.datetime | date: 'fullDate' }} for readable date. 